### PR TITLE
Use bundled AWS SDK bundle to prevent leakage in third party JARs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,7 @@ RUN set -euo pipefail && \
     AWS_JAVA_SDK_VERSION="$(curl -s https://raw.githubusercontent.com/apache/hadoop/branch-${HADOOP_VERSION}/hadoop-project/pom.xml | grep -A1 aws-java-sdk | grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" | tr "\r\n" " " | cut -d " " -f 1)"; \
     ## Download the JAR
     curl -LO http://central.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar; \
-    curl -LO https://sdk-for-java.amazonwebservices.com/aws-java-sdk-${AWS_JAVA_SDK_VERSION}.zip; \
-        unzip -qq aws-java-sdk-${AWS_JAVA_SDK_VERSION}.zip; \
-        find aws-java-sdk-${AWS_JAVA_SDK_VERSION} -name "*.jar" -exec mv {} ${SPARK_HOME}/jars/ \; ; \
-        rm -r ./aws-java-sdk-${AWS_JAVA_SDK_VERSION}; \
-        rm ./aws-java-sdk-${AWS_JAVA_SDK_VERSION}.zip; \
+    curl -LO https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_JAVA_SDK_VERSION}/aws-java-sdk-bundle-${AWS_JAVA_SDK_VERSION}.jar; \
     # AWS IAM Authenticator
     curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator; \
     chmod +x aws-iam-authenticator; \


### PR DESCRIPTION
Especially when it comes to `jackson` libraries, which clashes with the ones in `/opt/spark/jars`.

Related link: https://aws.amazon.com/blogs/developer/java-sdk-bundle/