### PR TITLE
Fix py4j PYTHONPATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,14 @@ matrix:
     - HADOOP_VERSION=3.1.0
 
 script:
+- PY4J_SRC="$(docker run --rm -t --entrypoint sh "${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}" -c 'ls ${SPARK_HOME}/python/lib/py4j-*.zip')"
 - |-
   docker build . \
-    --build-arg FROM_DOCKER_IMAGE \
-    --build-arg SPARK_VERSION=${SPARK_VERSION} \
-    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+    --build-arg FROM_DOCKER_IMAGE="${FROM_DOCKER_IMAGE}" \
+    --build-arg FROM_PY_DOCKER_IMAGE="${FROM_PY_DOCKER_IMAGE}" \
+    --build-arg SPARK_VERSION="${SPARK_VERSION}" \
+    --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
+    --build-arg PY4J_SRC="${PY4J_SRC}" \
     -t "${IMAGE_NAME}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}"
 
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG FROM_DOCKER_IMAGE="guangie88/spark-k8s"
 ARG FROM_PY_DOCKER_IMAGE="guangie88/spark-k8s-py"
 ARG SPARK_VERSION=
 ARG HADOOP_VERSION=
+ARG PY4J_SRC=
 
 # For copying of pyspark + py4j only
 FROM ${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION} as pybase
@@ -13,7 +14,7 @@ FROM ${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION} as pybase
 FROM ${FROM_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}
 
 COPY --from=pybase "${SPARK_HOME}/python" "${SPARK_HOME}/python"
-ENV PYTHONPATH="${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-*.zip"
+ENV PYTHONPATH="${SPARK_HOME}/python/lib/pyspark.zip:${PY4J_SRC}"
 
 ARG HADOOP_VERSION=
 

--- a/templates/.travis.yml.tmpl
+++ b/templates/.travis.yml.tmpl
@@ -16,11 +16,14 @@ matrix:
 {%- endfor %}
 
 script:
+- PY4J_SRC="$(docker run --rm -t --entrypoint sh "${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}" -c 'ls ${SPARK_HOME}/python/lib/py4j-*.zip')"
 - |-
   docker build . \
-    --build-arg FROM_DOCKER_IMAGE \
-    --build-arg SPARK_VERSION=${SPARK_VERSION} \
-    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+    --build-arg FROM_DOCKER_IMAGE="${FROM_DOCKER_IMAGE}" \
+    --build-arg FROM_PY_DOCKER_IMAGE="${FROM_PY_DOCKER_IMAGE}" \
+    --build-arg SPARK_VERSION="${SPARK_VERSION}" \
+    --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
+    --build-arg PY4J_SRC="${PY4J_SRC}" \
     -t "${IMAGE_NAME}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}"
 
 deploy:


### PR DESCRIPTION
Docker `ENV` cannot use wildcard, so the exact zip file path has to be queried before passing in as a build arg for `PYTHONPATH`.