### PR TITLE
Switch to using compiled conda instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN set -euo pipefail && \
     ## Note that this set-up will never activate the environment and rather
     ## globally adds to PATH so that every user can access the installed stuff
     ## without going through conda activate
-    conda create -p "${CONDA_PREFIX}"; \
+    conda create -y -p "${CONDA_PREFIX}"; \
     conda config --add channels conda-forge; \
     :
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN set -euo pipefail && \
     # AWS CLI
     ## We use the weakest possible version of Python so that the deriving image
     ## can easily upgrade the Python version later on
-    conda install python=2.7 awscli; \
+    conda install -y python=2.7 awscli; \
     conda clean -a -y; \
     # Google Storage JAR
     wget https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,12 @@ ENV PYTHONPATH="${SPARK_HOME}/python/lib/pyspark.zip:${PY4J_SRC}"
 
 ARG HADOOP_VERSION=
 
-# The miniconda version doesn't matter much because
-# it is just a means to create an environment with your required Python packages
-ARG CONDA_HOME=/opt/conda
-ENV CONDA_HOME="${CONDA_HOME}"
+# This directory will hold all the bins and libs installed via conda
+ARG CONDA_PREFIX=/opt/conda/default
+ENV CONDA_PREFIX="${CONDA_PREFIX}"
 
-# We pick 4.5 because it is just before the major change to conda init and also
-# downgrading and upgrading Python is easy at this version on the base env
-ARG MINICONDA3_VERSION=4.5.12
+# The conda3 version shouldn't matter much, can just take the latest
+ARG MINICONDA3_VERSION=4.7.12
 
 # The glibc version for Alpine doesn't matter much either
 # as long as all the symbols we need are there
@@ -46,15 +44,25 @@ RUN set -euo pipefail && \
     wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${ALPINE_GLIBC_VERSION}-r0/glibc-i18n-${ALPINE_GLIBC_VERSION}-r0.apk"; \
     apk add "glibc-${ALPINE_GLIBC_VERSION}-r0.apk" "glibc-bin-${ALPINE_GLIBC_VERSION}-r0.apk" "glibc-i18n-${ALPINE_GLIBC_VERSION}-r0.apk"; \
     rm "glibc-${ALPINE_GLIBC_VERSION}-r0.apk" "glibc-bin-${ALPINE_GLIBC_VERSION}-r0.apk" "glibc-i18n-${ALPINE_GLIBC_VERSION}-r0.apk"; \
-    ## Finally install conda
-    wget "https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA3_VERSION}-Linux-x86_64.sh"; \
-    bash "Miniconda3-${MINICONDA3_VERSION}-Linux-x86_64.sh" -b -p "${CONDA_HOME}"; \
-    rm "Miniconda3-${MINICONDA3_VERSION}-Linux-x86_64.sh"; \
-    # Version 4.5 and below does not require the below line
-    # "${CONDA_HOME}/bin/conda" init bash; \
+    ## We install a special compiled and linked version of conda
+    ## The original .sh conda assumes preset Python version, and upgrading the
+    ## base env Python version will immediately break conda
+    ## Using the pre-linked conda makes the set-up completely independent from
+    ## the Python version (in fact there is no default Python version to speak)
+    wget "https://repo.anaconda.com/pkgs/misc/conda-execs/conda-${MINICONDA3_VERSION}-linux-64.exe";\
+    mv "conda-${MINICONDA3_VERSION}-linux-64.exe" /usr/local/bin/conda; \
+    chmod +x /usr/local/bin/conda; \
+    ## Create the basic configuration for installation later
+    ## Note that this set-up will never activate the environment and rather
+    ## globally adds to PATH so that every user can access the installed stuff
+    ## without going through conda activate
+    conda create -p "${CONDA_PREFIX}"; \
+    conda config --add channels conda-forge; \
     :
 
-ENV PATH="${PATH}:${SPARK_HOME}/bin:${CONDA_HOME}/bin"
+# We set conda with higher precedence on purpose here to handle all Python
+# related packages over the system package manager
+ENV PATH="${CONDA_PREFIX}/bin:${PATH}:${SPARK_HOME}/bin"
 
 RUN set -euo pipefail && \
     # apt requirements
@@ -74,8 +82,9 @@ RUN set -euo pipefail && \
     chmod +x aws-iam-authenticator; \
     mv aws-iam-authenticator /usr/local/bin/; \
     # AWS CLI
-    conda config --add channels conda-forge; \
-    conda install awscli; \
+    ## We use the weakest possible version of Python so that the deriving image
+    ## can easily upgrade the Python version later on
+    conda install python=2.7 awscli; \
     conda clean -a -y; \
     # Google Storage JAR
     wget https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar; \

--- a/README.md
+++ b/README.md
@@ -30,13 +30,24 @@ The following command-line tools have been added onto the original K8s Docker
 images:
 
 - Miniconda3 (i.e. `conda` command)
-  - No guarantee of which exact Python 3 version, since the intent is to allow
-    `conda` to create new environments with any Python version of the user's
-    liking in the downstream Docker images. Note that however to use
-    `conda create -n xxx` command properly, the user has to be `root` instead of
-    `spark`.
-- [AWS CLI](https://aws.amazon.com/cli/) installed via `conda`
+  - This specially uses the compiled and linked variants found
+    [here](https://repo.anaconda.com/pkgs/misc/conda-execs/), so that upgrading
+    Python in deriving images will not affect `conda` command itself. This does
+    not require any preset Python version to run `conda` as a result. The set-up
+    also generally assumes to never perform `conda activate` so that the
+    deriving images do not need to worry which environment to install to.
+    However, do note that the user has to be `root` instead of `spark` to
+    install anything from `conda`. `conda install` always installs into the
+    default `conda` environment, as defined by `CONDA_PREFIX` environment
+    variable.
+- [AWS CLI](https://aws.amazon.com/cli/) installed via `conda`. Since `aws` CLI
+  requires Python, this forces a certain version of Python to be installed into
+  the default `conda` environment, but the Python version is left unspecified.
+  (Though we generally try to pick the lowest possible Python version for
+  easier Python version upgrade in deriving images).
 - [AWS IAM Authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator)
+  This is a Go statically linked binary, so this does not interact with any of
+  the above said items.
 
 ### JARs
 


### PR DESCRIPTION
The earlier PR doesn't work well because the `conda`'s dependencies (which most importantly include the Python version) is tied to the `base` environment's Python version, which is a disaster.

This completely segregates the `conda` executable from any environments that it creates, by using the compiled and linked form, which doesn't even require Python to run it.