### PR TITLE
feat: switch to Debian based set-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,16 @@ jobs:
     strategy:
       matrix:
         version:
-        - spark:  "2.4.4"
-          hadoop: "3.1.0"
-          scala:  "2.11"
-        - spark:  "2.4.4"
-          hadoop: "3.1.0"
+        - spark:  "3.0.0-preview-rc2"
+          hadoop: "3.2.0"
+          scala:  "2.12"
+        - spark:  "3.0.0-preview2-rc2"
+          hadoop: "3.2.0"
           scala:  "2.12"
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: spark-k8s-addons
-      FROM_DOCKER_IMAGE: guangie88/spark-k8s
-      FROM_PY_DOCKER_IMAGE: guangie88/spark-k8s-py
-      SELF_VERSION: "v1"
+      SELF_VERSION: "v2"
       SPARK_VERSION: "${{ matrix.version.spark }}"
       HADOOP_VERSION: "${{ matrix.version.hadoop }}"
       SCALA_VERSION: "${{ matrix.version.scala }}"
@@ -48,8 +46,6 @@ jobs:
         echo "PY4J_SRC - ${PY4J_SRC}"
         TAG_NAME="${SELF_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
         docker build . -t "${IMAGE_NAME}:${TAG_NAME}" \
-          --build-arg FROM_DOCKER_IMAGE="${FROM_DOCKER_IMAGE}" \
-          --build-arg FROM_PY_DOCKER_IMAGE="${FROM_PY_DOCKER_IMAGE}" \
           --build-arg SPARK_VERSION="${SPARK_VERSION}" \
           --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
           --build-arg SCALA_VERSION="${SCALA_VERSION}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2
+
+- Switch to Debian base set-up due to official change in Kubernetes Docker base
+  image used.
+
 ## v1
 
 - Basic setup for Spark 2.4.4 from `v1`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ K8s Docker images.
 The Spark K8s Docker images are built using
 [this repository](https://github.com/guangie88/spark-k8s).
 
-Note that the images here are naturally Alpine based because of how the official
-script generates the Spark-Kubernetes images.
+Note that the images here are Debian based because of how the official script
+generates the Spark-Kubernetes images.
 
 ## Add-ons
 
@@ -17,12 +17,6 @@ script generates the Spark-Kubernetes images.
 
 A more human-friendly `spark` username has been added at UID 185, which is the
 default UID dictated by the official Spark-Kubernetes Docker image build.
-
-### Alpine `glibc`
-
-Additionally, the image is patched with `glibc` from
-<https://github.com/sgerrand/alpine-pkg-glibc/>, required by `conda` and also to
-prevent `glibc` shared library related issues.
 
 ### CLIs
 

--- a/templates/ci.yml.tmpl
+++ b/templates/ci.yml.tmpl
@@ -29,8 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: spark-k8s-addons
-      FROM_DOCKER_IMAGE: guangie88/spark-k8s
-      FROM_PY_DOCKER_IMAGE: guangie88/spark-k8s-py
       SELF_VERSION: "{{ self_version }}"
       {% raw -%}
       SPARK_VERSION: "${{ matrix.version.spark }}"
@@ -55,8 +53,6 @@ jobs:
         echo "PY4J_SRC - ${PY4J_SRC}"
         TAG_NAME="${SELF_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
         docker build . -t "${IMAGE_NAME}:${TAG_NAME}" \
-          --build-arg FROM_DOCKER_IMAGE="${FROM_DOCKER_IMAGE}" \
-          --build-arg FROM_PY_DOCKER_IMAGE="${FROM_PY_DOCKER_IMAGE}" \
           --build-arg SPARK_VERSION="${SPARK_VERSION}" \
           --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
           --build-arg SCALA_VERSION="${SCALA_VERSION}" \

--- a/templates/vars.yml
+++ b/templates/vars.yml
@@ -1,8 +1,6 @@
-self_version: "v1"
+self_version: "v2"
 
-# Do not include Spark versions <= 2.3.z because they do not have -py
-# counterparts to extract the PySpark packages from
 versions:
-- spark:  ["2.4.4"]
-  hadoop: ["3.1.0"]
-  scala:  ["2.11", "2.12"]
+- spark:  ["3.0.0-preview-rc2", "3.0.0-preview2-rc2"]
+  hadoop: ["3.2.0"]
+  scala:  ["2.12"]


### PR DESCRIPTION
This switches the base image to be Debian base, thus no longer any need
to use special `glibc` external deps.