### PR TITLE
feat(locale): add and use en_US.utf8 as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1
 
-- Add Postgres JDBC JAR
+- Set locale for Alpine to `en_US.utf8`.
+- Add Postgres JDBC JAR.
 - Basic setup for Spark 2.4.4 from `v1`
   [`spark-k8s`](https://github.com/guangie88/spark-k8s).


### PR DESCRIPTION
This follows <https://github.com/sgerrand/alpine-pkg-glibc#locales>
of providing a good default locale with UTF-8.