### PR TITLE
fix(conda): use installer with default prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       IMAGE_NAME: spark-k8s-addons
       SELF_VERSION: "v2"
+      BASE_VERSION: "v2"
       SPARK_VERSION: "${{ matrix.version.spark }}"
       HADOOP_VERSION: "${{ matrix.version.hadoop }}"
       SCALA_VERSION: "${{ matrix.version.scala }}"
@@ -48,10 +49,11 @@ jobs:
         if ! diff .github/workflows/ci.yml .github/workflows/ci.yml.backup; then echo "ci.yml.tmpl and ci.yml differs!" && exit 1; fi
     - name: Build Docker image
       run: |-
-        PY4J_SRC="$(docker run --rm -t --entrypoint sh "${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}" -c 'ls --color=never ${SPARK_HOME}/python/lib/py4j-*.zip' | tr -d "\r\n")"
+        PY4J_SRC="$(docker run --rm -t --entrypoint sh "guangie88/spark-k8s-py:${BASE_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}" -c 'ls --color=never ${SPARK_HOME}/python/lib/py4j-*.zip' | tr -d "\r\n")"
         echo "PY4J_SRC - ${PY4J_SRC}"
         TAG_NAME="${SELF_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
         docker build . -t "${IMAGE_NAME}:${TAG_NAME}" \
+          --build-arg BASE_VERSION="${BASE_VERSION}" \
           --build-arg SPARK_VERSION="${SPARK_VERSION}" \
           --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
           --build-arg SCALA_VERSION="${SCALA_VERSION}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2
 
+- `CONDA_PREFIX` is the default prefix to contain all `conda install` bins and
+  libs. `PATH` is prepended with `${CONDA_PREFIX}/bin` so that the executables
+  in this default Conda prefix will take precedence.
 - Switch to Debian base set-up due to official change in Kubernetes Docker base
   image used.
 

--- a/templates/ci.yml.tmpl
+++ b/templates/ci.yml.tmpl
@@ -30,6 +30,7 @@ jobs:
     env:
       IMAGE_NAME: spark-k8s-addons
       SELF_VERSION: "{{ self_version }}"
+      BASE_VERSION: "v2"
       {% raw -%}
       SPARK_VERSION: "${{ matrix.version.spark }}"
       HADOOP_VERSION: "${{ matrix.version.hadoop }}"
@@ -49,10 +50,11 @@ jobs:
         if ! diff .github/workflows/ci.yml .github/workflows/ci.yml.backup; then echo "ci.yml.tmpl and ci.yml differs!" && exit 1; fi
     - name: Build Docker image
       run: |-
-        PY4J_SRC="$(docker run --rm -t --entrypoint sh "${FROM_PY_DOCKER_IMAGE}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}" -c 'ls --color=never ${SPARK_HOME}/python/lib/py4j-*.zip' | tr -d "\r\n")"
+        PY4J_SRC="$(docker run --rm -t --entrypoint sh "guangie88/spark-k8s-py:${BASE_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}" -c 'ls --color=never ${SPARK_HOME}/python/lib/py4j-*.zip' | tr -d "\r\n")"
         echo "PY4J_SRC - ${PY4J_SRC}"
         TAG_NAME="${SELF_VERSION}_${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
         docker build . -t "${IMAGE_NAME}:${TAG_NAME}" \
+          --build-arg BASE_VERSION="${BASE_VERSION}" \
           --build-arg SPARK_VERSION="${SPARK_VERSION}" \
           --build-arg HADOOP_VERSION="${HADOOP_VERSION}" \
           --build-arg SCALA_VERSION="${SCALA_VERSION}" \


### PR DESCRIPTION
The standalone version does not work well since the executable
components in conda are not directly accessible.

Switch back to the installer version but install the default packages
into a default prefix.