### PR TITLE
fix(workdir): allow `spark` user to write into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `pyenv` and use native Python only. `pip` installation is recommended
   to be managed by `poetry`.
+- Change group of `/opt/spark/work-dir` to be `spark` instead of `root`.
 
 ## v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,8 @@ ARG SPARK_USER_UID=185
 # This will not affect the original spark-k8s set-up
 RUN set -euo pipefail && \
     adduser --disabled-password --gecos "" -u "${SPARK_USER_UID}" "${SPARK_USER}"; \
+    # Amend the work-dir, which is a scratch space for running Spark to be usable by group `spark`
+    chown root:spark "${SPARK_HOME}/work-dir"; \
     :
 
 USER ${SPARK_USER}


### PR DESCRIPTION
Otherwise certain Spark ops that require the intended `spark` user to
write into the scratch space `work-dir` might fail.